### PR TITLE
Change color scheme to red/black/white (GH-1)

### DIFF
--- a/app.json
+++ b/app.json
@@ -35,7 +35,7 @@
           "resizeMode": "contain",
           "backgroundColor": "#ffffff",
           "dark": {
-            "backgroundColor": "#000000"
+            "backgroundColor": "#ffffff"
           }
         }
       ]

--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -12,11 +12,11 @@ import { Fonts } from '@/constants/theme';
 export default function TabTwoScreen() {
   return (
     <ParallaxScrollView
-      headerBackgroundColor={{ light: '#D0D0D0', dark: '#353636' }}
+      headerBackgroundColor={{ light: '#F5F5F5', dark: '#F5F5F5' }}
       headerImage={
         <IconSymbol
           size={310}
-          color="#808080"
+          color="#CCCCCC"
           name="chevron.left.forwardslash.chevron.right"
           style={styles.headerImage}
         />
@@ -100,7 +100,7 @@ export default function TabTwoScreen() {
 
 const styles = StyleSheet.create({
   headerImage: {
-    color: '#808080',
+    color: '#CCCCCC',
     bottom: -90,
     left: -35,
     position: 'absolute',

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,4 +1,4 @@
-import { DarkTheme, ThemeProvider } from '@react-navigation/native';
+import { DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
@@ -7,16 +7,16 @@ export const unstable_settings = {
   anchor: '(tabs)',
 };
 
-// Force the custom dark theme (deep black + red accent) globally
+// Light theme — red, black, white
 const AppTheme = {
-  ...DarkTheme,
+  ...DefaultTheme,
   colors: {
-    ...DarkTheme.colors,
-    background: '#1a1a1a',
-    card: '#111111',
-    border: '#333333',
+    ...DefaultTheme.colors,
+    background: '#FFFFFF',
+    card: '#FFFFFF',
+    border: '#E0E0E0',
     primary: '#E53935',
-    text: '#FFFFFF',
+    text: '#000000',
     notification: '#E53935',
   },
 };
@@ -34,7 +34,7 @@ export default function RootLayout() {
         <Stack.Screen name="routine/[id]" options={{ headerShown: false }} />
         <Stack.Screen name="memories" options={{ headerShown: false }} />
       </Stack>
-      <StatusBar style="light" />
+      <StatusBar style="dark" />
     </ThemeProvider>
   );
 }

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -1,11 +1,11 @@
 import { Platform } from 'react-native';
 
-// Dark theme only — forced app-wide
+// Light theme — red, black, white
 export const Colors = {
-  background: '#1a1a1a',
-  surface: '#242424',
-  surfaceElevated: '#2e2e2e',
-  border: '#333333',
+  background: '#FFFFFF',
+  surface: '#F5F5F5',
+  surfaceElevated: '#FFFFFF',
+  border: '#E0E0E0',
 
   // Red accent
   accent: '#E53935',
@@ -13,33 +13,33 @@ export const Colors = {
   accentLight: '#EF5350',
 
   // Text
-  textPrimary: '#FFFFFF',
-  textSecondary: '#9CA3AF',
-  textMuted: '#6B7280',
+  textPrimary: '#000000',
+  textSecondary: '#444444',
+  textMuted: '#888888',
 
   // Status
   success: '#22C55E',
 
   // Tab bar
-  tabBar: '#111111',
-  tabIconDefault: '#6B7280',
+  tabBar: '#FFFFFF',
+  tabIconDefault: '#888888',
   tabIconSelected: '#E53935',
 
   // Legacy shape required by expo-router (light/dark keys)
   light: {
-    text: '#FFFFFF',
-    background: '#1a1a1a',
+    text: '#000000',
+    background: '#FFFFFF',
     tint: '#E53935',
-    icon: '#9CA3AF',
-    tabIconDefault: '#6B7280',
+    icon: '#444444',
+    tabIconDefault: '#888888',
     tabIconSelected: '#E53935',
   },
   dark: {
-    text: '#FFFFFF',
-    background: '#1a1a1a',
+    text: '#000000',
+    background: '#FFFFFF',
     tint: '#E53935',
-    icon: '#9CA3AF',
-    tabIconDefault: '#6B7280',
+    icon: '#444444',
+    tabIconDefault: '#888888',
     tabIconSelected: '#E53935',
   },
 };


### PR DESCRIPTION
## Summary
- Replaced dark gray theme with clean white backgrounds, black text, and red accents
- Updated `constants/theme.ts`, `app/_layout.tsx`, `app/(tabs)/explore.tsx`, and `app.json`
- Switched navigation from `DarkTheme` to `DefaultTheme`, status bar to dark style

## Test plan
- [ ] Verify all screens render with white backgrounds and black text
- [ ] Confirm red accent buttons/badges still show white text
- [ ] Check tab bar appears white with red selected icon
- [ ] Verify splash screen is white in both light and dark system modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)