### PR TITLE
Add profile picture picker

### DIFF
--- a/app.json
+++ b/app.json
@@ -38,6 +38,13 @@
             "backgroundColor": "#000000"
           }
         }
+      ],
+      [
+        "expo-image-picker",
+        {
+          "cameraPermission": "Allow Workout Tracker to take profile photos.",
+          "photosPermission": "Allow Workout Tracker to choose a profile photo."
+        }
       ]
     ],
     "experiments": {

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,7 +1,9 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useFocusEffect, useRouter } from 'expo-router';
+import * as ImagePicker from 'expo-image-picker';
 import React, { useCallback, useMemo, useState } from 'react';
 import {
+  Image,
   KeyboardAvoidingView,
   Modal,
   Platform,
@@ -16,7 +18,8 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { Colors } from '@/constants/theme';
 import { WorkoutLog } from '@/constants/mockData';
-import { loadPoints, loadWorkoutHistory } from '@/constants/storage';
+import { loadPoints, loadWorkoutHistory, loadProfile, saveProfile } from '@/constants/storage';
+import type { ProfileData } from '@/constants/storage';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -399,13 +402,7 @@ const GOAL_OPTIONS = [
   'Athletic Performance',
 ];
 
-type ProfileData = {
-  name: string;
-  goal: string;
-  age: string;
-  weight: string;
-  height: string;
-};
+type ProfileFormData = Omit<ProfileData, 'pictureUri'>;
 
 function EditProfileModal({
   visible,
@@ -414,17 +411,17 @@ function EditProfileModal({
   onClose,
 }: {
   visible: boolean;
-  initial: ProfileData;
-  onSave: (data: ProfileData) => void;
+  initial: ProfileFormData;
+  onSave: (data: ProfileFormData) => void;
   onClose: () => void;
 }) {
-  const [draft, setDraft] = useState<ProfileData>(initial);
+  const [draft, setDraft] = useState<ProfileFormData>(initial);
 
   React.useEffect(() => {
     if (visible) setDraft(initial);
   }, [visible]);
 
-  function set(field: keyof ProfileData, value: string) {
+  function set(field: keyof ProfileFormData, value: string) {
     setDraft((prev) => ({ ...prev, [field]: value }));
   }
 
@@ -515,6 +512,22 @@ function EditProfileModal({
 
 // ─── Profile Screen ───────────────────────────────────────────────────────────
 
+async function pickImage(source: 'camera' | 'library'): Promise<string | null> {
+  const launch = source === 'camera'
+    ? ImagePicker.launchCameraAsync
+    : ImagePicker.launchImageLibraryAsync;
+
+  const result = await launch({
+    mediaTypes: ['images'],
+    allowsEditing: true,
+    aspect: [1, 1],
+    quality: 0.8,
+  });
+
+  if (result.canceled || result.assets.length === 0) return null;
+  return result.assets[0].uri;
+}
+
 export default function ProfileScreen() {
   const router = useRouter();
   const today = useMemo(() => new Date(), []);
@@ -525,19 +538,47 @@ export default function ProfileScreen() {
     age: '22',
     weight: '175',
     height: `5'11"`,
+    pictureUri: null,
   });
   const [editVisible, setEditVisible] = useState(false);
+  const [pickerVisible, setPickerVisible] = useState(false);
   const [totalPoints, setTotalPoints] = useState(0);
   const [workoutHistory, setWorkoutHistory] = useState<WorkoutLog[]>([]);
 
   useFocusEffect(
     useCallback(() => {
-      Promise.all([loadPoints(), loadWorkoutHistory()]).then(([pts, history]) => {
-        setTotalPoints(pts.totalPoints);
-        setWorkoutHistory(history);
-      });
+      Promise.all([loadPoints(), loadWorkoutHistory(), loadProfile()]).then(
+        ([pts, history, savedProfile]) => {
+          setTotalPoints(pts.totalPoints);
+          setWorkoutHistory(history);
+          setProfile(savedProfile);
+        }
+      );
     }, [])
   );
+
+  const handleProfileSave = useCallback((formData: ProfileFormData) => {
+    const updated = { ...profile, ...formData };
+    setProfile(updated);
+    saveProfile(updated);
+    setEditVisible(false);
+  }, [profile]);
+
+  const updatePicture = useCallback(async (source: 'camera' | 'library' | 'remove') => {
+    setPickerVisible(false);
+    if (source === 'remove') {
+      const updated = { ...profile, pictureUri: null };
+      setProfile(updated);
+      saveProfile(updated);
+      return;
+    }
+    const uri = await pickImage(source);
+    if (uri) {
+      const updated = { ...profile, pictureUri: uri };
+      setProfile(updated);
+      saveProfile(updated);
+    }
+  }, [profile]);
 
   // Derive workout days Set from stored history for calendar/frequency chart
   const workoutDays = useMemo(
@@ -580,9 +621,13 @@ export default function ProfileScreen() {
         <View style={styles.profileHeader}>
           <View style={styles.avatarWrap}>
             <View style={styles.avatar}>
-              <Ionicons name="person" size={40} color={Colors.textSecondary} />
+              {profile.pictureUri ? (
+                <Image source={{ uri: profile.pictureUri }} style={styles.avatarImage} />
+              ) : (
+                <Ionicons name="person" size={40} color={Colors.textSecondary} />
+              )}
             </View>
-            <TouchableOpacity style={styles.avatarEditBtn} onPress={() => setEditVisible(true)}>
+            <TouchableOpacity style={styles.avatarEditBtn} onPress={() => setPickerVisible(true)}>
               <Ionicons name="camera" size={12} color="#fff" />
             </TouchableOpacity>
           </View>
@@ -678,10 +723,44 @@ export default function ProfileScreen() {
 
       </ScrollView>
 
+      <Modal visible={pickerVisible} animationType="fade" transparent>
+        <TouchableOpacity
+          style={styles.overlay}
+          activeOpacity={1}
+          onPress={() => setPickerVisible(false)}
+        >
+          <View style={styles.actionSheet}>
+            <Text style={styles.actionSheetTitle}>Profile Photo</Text>
+            {Platform.OS !== 'web' && (
+              <TouchableOpacity style={styles.actionSheetBtn} onPress={() => updatePicture('camera')}>
+                <Ionicons name="camera-outline" size={20} color={Colors.textPrimary} />
+                <Text style={styles.actionSheetBtnText}>Take Photo</Text>
+              </TouchableOpacity>
+            )}
+            <TouchableOpacity style={styles.actionSheetBtn} onPress={() => updatePicture('library')}>
+              <Ionicons name="images-outline" size={20} color={Colors.textPrimary} />
+              <Text style={styles.actionSheetBtnText}>Choose from Library</Text>
+            </TouchableOpacity>
+            {profile.pictureUri && (
+              <TouchableOpacity style={styles.actionSheetBtn} onPress={() => updatePicture('remove')}>
+                <Ionicons name="trash-outline" size={20} color={Colors.accent} />
+                <Text style={[styles.actionSheetBtnText, { color: Colors.accent }]}>Remove Photo</Text>
+              </TouchableOpacity>
+            )}
+            <TouchableOpacity
+              style={[styles.actionSheetBtn, styles.actionSheetCancel]}
+              onPress={() => setPickerVisible(false)}
+            >
+              <Text style={[styles.actionSheetBtnText, { textAlign: 'center' }]}>Cancel</Text>
+            </TouchableOpacity>
+          </View>
+        </TouchableOpacity>
+      </Modal>
+
       <EditProfileModal
         visible={editVisible}
         initial={profile}
-        onSave={(data) => { setProfile(data); setEditVisible(false); }}
+        onSave={handleProfileSave}
         onClose={() => setEditVisible(false)}
       />
     </SafeAreaView>
@@ -720,6 +799,12 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     borderWidth: 3,
     borderColor: Colors.accent,
+    overflow: 'hidden',
+  },
+  avatarImage: {
+    width: 84,
+    height: 84,
+    borderRadius: 42,
   },
   avatarEditBtn: {
     position: 'absolute',
@@ -1034,6 +1119,42 @@ const styles = StyleSheet.create({
   menuSub: {
     fontSize: 11,
     color: Colors.textMuted,
+  },
+
+  // ── Photo picker action sheet
+  actionSheet: {
+    backgroundColor: Colors.surface,
+    borderRadius: 16,
+    marginHorizontal: 16,
+    marginBottom: 16,
+    overflow: 'hidden',
+  },
+  actionSheetTitle: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: Colors.textSecondary,
+    textAlign: 'center',
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+  actionSheetBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 14,
+    paddingHorizontal: 20,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+  actionSheetBtnText: {
+    fontSize: 15,
+    color: Colors.textPrimary,
+    fontWeight: '500',
+  },
+  actionSheetCancel: {
+    justifyContent: 'center',
+    borderBottomWidth: 0,
   },
 
   // ── Edit modal

--- a/constants/storage.ts
+++ b/constants/storage.ts
@@ -7,6 +7,42 @@ import {
   DEFAULT_TOTAL_POINTS,
 } from './points';
 
+// ─── Profile ─────────────────────────────────────────────────────────────────
+
+export type ProfileData = {
+  name: string;
+  goal: string;
+  age: string;
+  weight: string;
+  height: string;
+  pictureUri: string | null;
+};
+
+const PROFILE_KEY = '@workout_tracker:profile';
+
+const DEFAULT_PROFILE: ProfileData = {
+  name: 'Liam',
+  goal: 'Build Muscle',
+  age: '22',
+  weight: '175',
+  height: `5'11"`,
+  pictureUri: null,
+};
+
+export async function loadProfile(): Promise<ProfileData> {
+  try {
+    const raw = await AsyncStorage.getItem(PROFILE_KEY);
+    if (raw === null) return DEFAULT_PROFILE;
+    return { ...DEFAULT_PROFILE, ...JSON.parse(raw) };
+  } catch {
+    return DEFAULT_PROFILE;
+  }
+}
+
+export async function saveProfile(profile: ProfileData): Promise<void> {
+  await AsyncStorage.setItem(PROFILE_KEY, JSON.stringify(profile));
+}
+
 // ─── Schedule ─────────────────────────────────────────────────────────────────
 
 export type ScheduleEntry = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
+        "expo-image-picker": "^55.0.18",
         "expo-linking": "~8.0.11",
         "expo-router": "~6.0.23",
         "expo-splash-screen": "~31.0.13",
@@ -6164,6 +6165,27 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "55.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-55.0.0.tgz",
+      "integrity": "sha512-NOjp56wDrfuA5aiNAybBIjqIn1IxKeGJ8CECWZncQ/GzjZfyTYAHTCyeApYkdKkMBLHINzI4BbTGSlbCa0fXXQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "55.0.18",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-55.0.18.tgz",
+      "integrity": "sha512-lGpPGRu+7mE8qN0ma2boRsCmfOGbdHZ2bXTpWVeWly0JCZdogGlTrYFnhTqgS8+lmiRb/UCOs7iTm2P5Rra6kw==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~55.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
+    "expo-image-picker": "^55.0.18",
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.23",
     "expo-splash-screen": "~31.0.13",
@@ -40,9 +41,9 @@
   },
   "devDependencies": {
     "@types/react": "~19.1.0",
-    "typescript": "~5.9.2",
     "eslint": "^9.25.0",
-    "eslint-config-expo": "~10.0.0"
+    "eslint-config-expo": "~10.0.0",
+    "typescript": "~5.9.2"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- Adds `expo-image-picker` for selecting/taking profile photos
- Profile avatar now displays the chosen image (or a placeholder icon if none set)
- Camera button on avatar opens a custom action sheet with options to take photo, choose from library, or remove
- All profile data (name, goal, age, weight, height, picture) is now persisted to AsyncStorage
- Works across web, iOS, and Android

Closes #3

## Test plan
- [x] Tap camera button on profile avatar — action sheet appears
- [x] Choose from Library — image picker opens, selected image displays as avatar
- [x] Remove Photo option appears when a photo is set
- [x] Profile data persists after restarting the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)