### PR TITLE
Migrate app data to Supabase with per-user persistence (GH-7)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,12 +1,12 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useFocusEffect, useRouter } from 'expo-router';
 import React, { useCallback, useMemo, useState } from 'react';
-import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Image, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { Colors } from '@/constants/theme';
 import { WORKOUT_DAYS, ROUTINES, Routine } from '@/constants/mockData';
-import { loadRoutines, loadPoints } from '@/constants/storage';
+import { loadRoutines, loadPoints, loadProfile } from '@/constants/storage';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -189,11 +189,13 @@ export default function HomeScreen() {
   const router = useRouter();
   const [routines, setRoutines] = useState<Routine[]>(ROUTINES);
   const [totalPoints, setTotalPoints] = useState(0);
+  const [pictureUri, setPictureUri] = useState<string | null>(null);
 
   useFocusEffect(
     useCallback(() => {
       loadRoutines().then(setRoutines);
       loadPoints().then((p) => setTotalPoints(p.totalPoints));
+      loadProfile().then((p) => setPictureUri(p.pictureUri));
     }, [])
   );
 
@@ -213,12 +215,16 @@ export default function HomeScreen() {
             <Text style={styles.greeting}>{greeting}</Text>
             <Text style={styles.headerTitle}>Ready to grind?</Text>
           </View>
-          <TouchableOpacity style={styles.avatarButton}>
-            <Ionicons
-              name="person-circle-outline"
-              size={38}
-              color={Colors.textSecondary}
-            />
+          <TouchableOpacity style={styles.avatarButton} onPress={() => router.push('/(tabs)/profile')}>
+            {pictureUri ? (
+              <Image source={{ uri: pictureUri }} style={styles.avatarImage} />
+            ) : (
+              <Ionicons
+                name="person-circle-outline"
+                size={38}
+                color={Colors.textSecondary}
+              />
+            )}
           </TouchableOpacity>
         </View>
 
@@ -458,6 +464,11 @@ const styles = StyleSheet.create({
   },
   avatarButton: {
     padding: 4,
+  },
+  avatarImage: {
+    width: 38,
+    height: 38,
+    borderRadius: 19,
   },
 
   // Streak card

--- a/app/(tabs)/log.tsx
+++ b/app/(tabs)/log.tsx
@@ -18,6 +18,7 @@ import { Colors } from '@/constants/theme';
 import { EXERCISE_LIBRARY, ExerciseInfo, PREV_PERFORMANCE, WorkoutLog } from '@/constants/mockData';
 import { addWorkoutPoints, loadRoutines, loadSchedule, loadWorkoutHistory, saveWorkoutLog } from '@/constants/storage';
 import { calculateWorkoutPoints, computeCurrentStreak, WorkoutPointsEntry } from '@/constants/points';
+import { useAuth } from '@/contexts/AuthContext';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -60,6 +61,7 @@ function makeSet(): WorkoutSet {
 
 export default function LogScreen() {
   const router = useRouter();
+  const { user } = useAuth();
   const { routineId } = useLocalSearchParams<{ routineId?: string }>();
 
   const [elapsed, setElapsed] = useState(0);
@@ -238,7 +240,7 @@ export default function LogScreen() {
       isScheduledToday,
     });
 
-    await addWorkoutPoints(points);
+    await addWorkoutPoints(points, user?.id);
 
     // Save the workout to history so charts and history screen show real data
     const workoutLog: WorkoutLog = {
@@ -257,7 +259,7 @@ export default function LogScreen() {
         }))
         .filter((ex) => ex.sets.length > 0),
     };
-    await saveWorkoutLog(workoutLog);
+    await saveWorkoutLog(workoutLog, user?.id);
 
     setPendingPoints(points);
     setSummaryVisible(true);

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -20,6 +20,7 @@ import { Colors } from '@/constants/theme';
 import { WorkoutLog } from '@/constants/mockData';
 import { loadPoints, loadWorkoutHistory, loadProfile, saveProfile } from '@/constants/storage';
 import type { ProfileData } from '@/constants/storage';
+import { useAuth } from '@/contexts/AuthContext';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -561,23 +562,23 @@ export default function ProfileScreen() {
   const handleProfileSave = useCallback((formData: ProfileFormData) => {
     const updated = { ...profile, ...formData };
     setProfile(updated);
-    saveProfile(updated);
+    saveProfile(updated, user?.id);
     setEditVisible(false);
-  }, [profile]);
+  }, [profile, user]);
 
   const updatePicture = useCallback(async (source: 'camera' | 'library' | 'remove') => {
     setPickerVisible(false);
     if (source === 'remove') {
       const updated = { ...profile, pictureUri: null };
       setProfile(updated);
-      saveProfile(updated);
+      saveProfile(updated, user?.id);
       return;
     }
     const uri = await pickImage(source);
     if (uri) {
       const updated = { ...profile, pictureUri: uri };
       setProfile(updated);
-      saveProfile(updated);
+      saveProfile(updated, user?.id);
     }
   }, [profile]);
 

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -21,6 +21,7 @@ import { WorkoutLog } from '@/constants/mockData';
 import { loadPoints, loadWorkoutHistory, loadProfile, saveProfile } from '@/constants/storage';
 import type { ProfileData } from '@/constants/storage';
 import { useAuth } from '@/contexts/AuthContext';
+import { getSupabase } from '@/lib/supabase';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -574,13 +575,29 @@ export default function ProfileScreen() {
       saveProfile(updated, user?.id);
       return;
     }
-    const uri = await pickImage(source);
-    if (uri) {
-      const updated = { ...profile, pictureUri: uri };
-      setProfile(updated);
-      saveProfile(updated, user?.id);
+    const localUri = await pickImage(source);
+    if (!localUri) return;
+
+    let pictureUri = localUri;
+
+    if (user?.id) {
+      try {
+        const response = await fetch(localUri);
+        const blob = await response.blob();
+        const filePath = `${user.id}/profile.jpg`;
+        await getSupabase().storage.from('avatars').upload(filePath, blob, {
+          upsert: true,
+          contentType: 'image/jpeg',
+        });
+        const { data } = getSupabase().storage.from('avatars').getPublicUrl(filePath);
+        pictureUri = `${data.publicUrl}?t=${Date.now()}`;
+      } catch {}
     }
-  }, [profile]);
+
+    const updated = { ...profile, pictureUri };
+    setProfile(updated);
+    saveProfile(updated, user?.id);
+  }, [profile, user]);
 
   // Derive workout days Set from stored history for calendar/frequency chart
   const workoutDays = useMemo(

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -69,6 +69,16 @@ function RootNavigator() {
   );
 }
 
+export default function RootLayout() {
+  return (
+    <ThemeProvider value={AppTheme}>
+      <AuthProvider>
+        <RootNavigator />
+      </AuthProvider>
+    </ThemeProvider>
+  );
+}
+
 const styles = StyleSheet.create({
   loading: {
     flex: 1,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,4 +1,4 @@
-import { DarkTheme, ThemeProvider } from '@react-navigation/native';
+import { DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { Stack, useRouter, useSegments } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import React, { useEffect } from 'react';
@@ -65,7 +65,7 @@ function RootNavigator() {
         <Stack.Screen name="memories" options={{ headerShown: false }} />
       </Stack>
       <StatusBar style="dark" />
-    </ThemeProvider>
+    </>
   );
 }
 

--- a/app/routine/[id].tsx
+++ b/app/routine/[id].tsx
@@ -24,6 +24,7 @@ import {
   Routine,
 } from '@/constants/mockData';
 import { loadRoutines, upsertRoutine } from '@/constants/storage';
+import { useAuth } from '@/contexts/AuthContext';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -57,6 +58,7 @@ function routineToEntries(routine: Routine): RoutineEntry[] {
 
 export default function RoutineEditorScreen() {
   const router = useRouter();
+  const { user } = useAuth();
   const { id } = useLocalSearchParams<{ id: string }>();
   const isNew = id === 'new';
 
@@ -189,7 +191,7 @@ export default function RoutineEditorScreen() {
 
     setSaving(true);
     try {
-      await upsertRoutine(routine);
+      await upsertRoutine(routine, user?.id);
       router.back();
     } catch {
       Alert.alert('Error', 'Could not save routine. Please try again.');

--- a/app/schedule.tsx
+++ b/app/schedule.tsx
@@ -20,6 +20,7 @@ import {
   loadSchedule,
   saveSchedule,
 } from '@/constants/storage';
+import { useAuth } from '@/contexts/AuthContext';
 
 const TODAY_DOW = new Date().toLocaleDateString('en-US', { weekday: 'long' });
 
@@ -113,6 +114,7 @@ function RoutinePicker({
 
 export default function ScheduleScreen() {
   const router = useRouter();
+  const { user } = useAuth();
 
   const [schedule, setSchedule] = useState<ScheduleEntry[]>([]);
   const [routines, setRoutines] = useState<Routine[]>([]);
@@ -153,7 +155,7 @@ export default function ScheduleScreen() {
   async function saveEdit() {
     setSaving(true);
     try {
-      await saveSchedule(draft);
+      await saveSchedule(draft, user?.id);
       setSchedule(draft);
       setEditMode(false);
     } finally {
@@ -169,7 +171,7 @@ export default function ScheduleScreen() {
       );
       setSchedule(updated);
       setDraft(updated);
-      await saveSchedule(updated);
+      await saveSchedule(updated, user?.id);
     } else {
       setDraft((prev) =>
         prev.map((entry, i) => (i === dayIndex ? { ...entry, routineId } : entry))

--- a/constants/storage.ts
+++ b/constants/storage.ts
@@ -6,6 +6,13 @@ import {
   DEFAULT_POINTS_HISTORY,
   DEFAULT_TOTAL_POINTS,
 } from './points';
+import {
+  syncProfileToSupabase,
+  syncRoutinesToSupabase,
+  syncScheduleToSupabase,
+  syncPointsToSupabase,
+  syncWorkoutLogToSupabase,
+} from '@/lib/sync';
 
 // ─── Profile ─────────────────────────────────────────────────────────────────
 
@@ -21,11 +28,11 @@ export type ProfileData = {
 const PROFILE_KEY = '@workout_tracker:profile';
 
 const DEFAULT_PROFILE: ProfileData = {
-  name: 'Liam',
+  name: '',
   goal: 'Build Muscle',
-  age: '22',
-  weight: '175',
-  height: `5'11"`,
+  age: '',
+  weight: '',
+  height: '',
   pictureUri: null,
 };
 
@@ -39,44 +46,43 @@ export async function loadProfile(): Promise<ProfileData> {
   }
 }
 
-export async function saveProfile(profile: ProfileData): Promise<void> {
+export async function saveProfile(profile: ProfileData, userId?: string): Promise<void> {
   await AsyncStorage.setItem(PROFILE_KEY, JSON.stringify(profile));
+  if (userId) syncProfileToSupabase(userId, profile);
 }
 
 // ─── Schedule ─────────────────────────────────────────────────────────────────
 
 export type ScheduleEntry = {
-  day: string;   // 'Monday' … 'Sunday'
-  routineId: string | null; // null = rest day
+  day: string;
+  routineId: string | null;
 };
 
 const SCHEDULE_KEY = '@workout_tracker:schedule';
 
 const DEFAULT_SCHEDULE: ScheduleEntry[] = [
-  { day: 'Monday',    routineId: 'r1' },
-  { day: 'Tuesday',   routineId: 'r2' },
+  { day: 'Monday',    routineId: null },
+  { day: 'Tuesday',   routineId: null },
   { day: 'Wednesday', routineId: null },
-  { day: 'Thursday',  routineId: 'r3' },
-  { day: 'Friday',    routineId: 'r1' },
-  { day: 'Saturday',  routineId: 'r4' },
+  { day: 'Thursday',  routineId: null },
+  { day: 'Friday',    routineId: null },
+  { day: 'Saturday',  routineId: null },
   { day: 'Sunday',    routineId: null },
 ];
 
 export async function loadSchedule(): Promise<ScheduleEntry[]> {
   try {
     const raw = await AsyncStorage.getItem(SCHEDULE_KEY);
-    if (raw === null) {
-      await AsyncStorage.setItem(SCHEDULE_KEY, JSON.stringify(DEFAULT_SCHEDULE));
-      return DEFAULT_SCHEDULE;
-    }
+    if (raw === null) return DEFAULT_SCHEDULE;
     return JSON.parse(raw) as ScheduleEntry[];
   } catch {
     return DEFAULT_SCHEDULE;
   }
 }
 
-export async function saveSchedule(schedule: ScheduleEntry[]): Promise<void> {
+export async function saveSchedule(schedule: ScheduleEntry[], userId?: string): Promise<void> {
   await AsyncStorage.setItem(SCHEDULE_KEY, JSON.stringify(schedule));
+  if (userId) syncScheduleToSupabase(userId, schedule);
 }
 
 // ─── Points ───────────────────────────────────────────────────────────────────
@@ -84,106 +90,89 @@ export async function saveSchedule(schedule: ScheduleEntry[]): Promise<void> {
 const POINTS_KEY = '@workout_tracker:points';
 
 const DEFAULT_POINTS: PointsStore = {
-  totalPoints: DEFAULT_TOTAL_POINTS,
-  history: DEFAULT_POINTS_HISTORY,
+  totalPoints: 0,
+  history: [],
 };
 
 export async function loadPoints(): Promise<PointsStore> {
   try {
     const raw = await AsyncStorage.getItem(POINTS_KEY);
-    if (raw === null) {
-      await AsyncStorage.setItem(POINTS_KEY, JSON.stringify(DEFAULT_POINTS));
-      return DEFAULT_POINTS;
-    }
+    if (raw === null) return DEFAULT_POINTS;
     return JSON.parse(raw) as PointsStore;
   } catch {
     return DEFAULT_POINTS;
   }
 }
 
-export async function savePoints(store: PointsStore): Promise<void> {
+export async function savePoints(store: PointsStore, userId?: string): Promise<void> {
   await AsyncStorage.setItem(POINTS_KEY, JSON.stringify(store));
+  if (userId) syncPointsToSupabase(userId, store.totalPoints, store.history);
 }
 
-export async function addWorkoutPoints(entry: WorkoutPointsEntry): Promise<void> {
+export async function addWorkoutPoints(entry: WorkoutPointsEntry, userId?: string): Promise<void> {
   const store = await loadPoints();
-  // Avoid duplicate entries for the same workoutId
   const filtered = store.history.filter((e) => e.workoutId !== entry.workoutId);
   const updated: PointsStore = {
     totalPoints: filtered.reduce((s, e) => s + e.total, 0) + entry.total,
     history: [...filtered, entry].sort((a, b) => a.date.localeCompare(b.date)),
   };
-  await savePoints(updated);
+  await savePoints(updated, userId);
 }
+
+// ─── Routines ────────────────────────────────────────────────────────────────
 
 const ROUTINES_KEY = '@workout_tracker:routines';
 
-/**
- * Load routines from AsyncStorage.
- * First launch: seeds from ROUTINES mock data.
- */
 export async function loadRoutines(): Promise<Routine[]> {
   try {
     const raw = await AsyncStorage.getItem(ROUTINES_KEY);
-    if (raw === null) {
-      await AsyncStorage.setItem(ROUTINES_KEY, JSON.stringify(ROUTINES));
-      return ROUTINES;
-    }
+    if (raw === null) return [];
     return JSON.parse(raw) as Routine[];
   } catch {
-    return ROUTINES;
+    return [];
   }
 }
 
-/** Persist the full routines array. */
-export async function saveRoutines(routines: Routine[]): Promise<void> {
+export async function saveRoutines(routines: Routine[], userId?: string): Promise<void> {
   await AsyncStorage.setItem(ROUTINES_KEY, JSON.stringify(routines));
+  if (userId) syncRoutinesToSupabase(userId, routines);
 }
 
-/** Insert a new routine or replace an existing one by id. */
-export async function upsertRoutine(routine: Routine): Promise<void> {
+export async function upsertRoutine(routine: Routine, userId?: string): Promise<void> {
   const existing = await loadRoutines();
   const idx = existing.findIndex((r) => r.id === routine.id);
   const updated =
     idx >= 0
       ? existing.map((r) => (r.id === routine.id ? routine : r))
       : [...existing, routine];
-  await saveRoutines(updated);
+  await saveRoutines(updated, userId);
 }
 
-/** Remove a routine by id. */
-export async function deleteRoutine(id: string): Promise<void> {
+export async function deleteRoutine(id: string, userId?: string): Promise<void> {
   const existing = await loadRoutines();
-  await saveRoutines(existing.filter((r) => r.id !== id));
+  await saveRoutines(existing.filter((r) => r.id !== id), userId);
 }
 
 // ─── Workout History ──────────────────────────────────────────────────────────
 
 const WORKOUT_HISTORY_KEY = '@workout_tracker:workout_history';
 
-/**
- * Load workout history from AsyncStorage.
- * First launch: seeds from WORKOUT_HISTORY mock data.
- */
 export async function loadWorkoutHistory(): Promise<WorkoutLog[]> {
   try {
     const raw = await AsyncStorage.getItem(WORKOUT_HISTORY_KEY);
-    if (raw === null) {
-      await AsyncStorage.setItem(WORKOUT_HISTORY_KEY, JSON.stringify(WORKOUT_HISTORY));
-      return WORKOUT_HISTORY;
-    }
+    if (raw === null) return [];
     return JSON.parse(raw) as WorkoutLog[];
   } catch {
-    return WORKOUT_HISTORY;
+    return [];
   }
 }
 
-/** Append (or replace) a completed workout in storage. */
-export async function saveWorkoutLog(log: WorkoutLog): Promise<void> {
+export async function saveWorkoutLog(log: WorkoutLog, userId?: string): Promise<void> {
   const existing = await loadWorkoutHistory();
   const filtered = existing.filter((w) => w.id !== log.id);
   await AsyncStorage.setItem(
     WORKOUT_HISTORY_KEY,
     JSON.stringify([...filtered, log])
   );
+  if (userId) syncWorkoutLogToSupabase(userId, log);
 }

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -3,6 +3,7 @@ import React, { createContext, useCallback, useContext, useEffect, useState } fr
 import { Platform } from 'react-native';
 
 import { getSupabase } from '@/lib/supabase';
+import { fullSyncFromSupabase } from '@/lib/sync';
 
 type AuthState = {
   session: Session | null;
@@ -26,8 +27,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setIsLoading(false);
     });
 
-    const { data: { subscription } } = getSupabase().auth.onAuthStateChange((_event, s) => {
+    const { data: { subscription } } = getSupabase().auth.onAuthStateChange((event, s) => {
       setSession(s);
+      if (s?.user && (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED')) {
+        fullSyncFromSupabase(s.user.id);
+      }
     });
 
     return () => subscription.unsubscribe();

--- a/lib/sync.ts
+++ b/lib/sync.ts
@@ -1,0 +1,323 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { getSupabase } from './supabase';
+import type { Routine, WorkoutLog } from '@/constants/mockData';
+import type { WorkoutPointsEntry } from '@/constants/points';
+import type { ProfileData, ScheduleEntry } from '@/constants/storage';
+
+const PROFILE_KEY = '@workout_tracker:profile';
+const SCHEDULE_KEY = '@workout_tracker:schedule';
+const POINTS_KEY = '@workout_tracker:points';
+const ROUTINES_KEY = '@workout_tracker:routines';
+const WORKOUT_HISTORY_KEY = '@workout_tracker:workout_history';
+
+// ─── Profile ─────────────────────────────────────────────────────────────────
+
+export async function syncProfileToSupabase(userId: string, profile: ProfileData) {
+  try {
+    await getSupabase().from('profiles').upsert({
+      id: userId,
+      name: profile.name,
+      goal: profile.goal,
+      age: profile.age,
+      weight: profile.weight,
+      height: profile.height,
+      picture_url: profile.pictureUri,
+      updated_at: new Date().toISOString(),
+    });
+  } catch {}
+}
+
+export async function fetchProfileFromSupabase(userId: string): Promise<ProfileData | null> {
+  try {
+    const { data } = await getSupabase()
+      .from('profiles')
+      .select('*')
+      .eq('id', userId)
+      .single();
+    if (!data) return null;
+    return {
+      name: data.name,
+      goal: data.goal,
+      age: data.age,
+      weight: data.weight,
+      height: data.height,
+      pictureUri: data.picture_url,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ─── Routines ────────────────────────────────────────────────────────────────
+
+export async function syncRoutinesToSupabase(userId: string, routines: Routine[]) {
+  try {
+    await getSupabase().from('routines').delete().eq('user_id', userId);
+    if (routines.length > 0) {
+      await getSupabase().from('routines').upsert(
+        routines.map((r) => ({
+          id: r.id,
+          user_id: userId,
+          name: r.name,
+          tag: r.tag,
+          exercises: r.exercises,
+          updated_at: new Date().toISOString(),
+        })),
+        { onConflict: 'id,user_id' }
+      );
+    }
+  } catch {}
+}
+
+export async function fetchRoutinesFromSupabase(userId: string): Promise<Routine[] | null> {
+  try {
+    const { data } = await getSupabase()
+      .from('routines')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at');
+    if (!data) return null;
+    return data.map((r) => ({
+      id: r.id,
+      name: r.name,
+      tag: r.tag,
+      exercises: r.exercises as Routine['exercises'],
+    }));
+  } catch {
+    return null;
+  }
+}
+
+// ─── Schedule ────────────────────────────────────────────────────────────────
+
+export async function syncScheduleToSupabase(userId: string, schedule: ScheduleEntry[]) {
+  try {
+    await getSupabase().from('schedules').delete().eq('user_id', userId);
+    if (schedule.length > 0) {
+      await getSupabase().from('schedules').upsert(
+        schedule.map((s) => ({
+          user_id: userId,
+          day: s.day,
+          routine_id: s.routineId,
+        })),
+        { onConflict: 'user_id,day' }
+      );
+    }
+  } catch {}
+}
+
+export async function fetchScheduleFromSupabase(userId: string): Promise<ScheduleEntry[] | null> {
+  try {
+    const { data } = await getSupabase()
+      .from('schedules')
+      .select('*')
+      .eq('user_id', userId);
+    if (!data || data.length === 0) return null;
+    return data.map((s) => ({
+      day: s.day,
+      routineId: s.routine_id,
+    }));
+  } catch {
+    return null;
+  }
+}
+
+// ─── Workout History ─────────────────────────────────────────────────────────
+
+export async function syncWorkoutLogToSupabase(userId: string, log: WorkoutLog) {
+  try {
+    await getSupabase().from('workout_logs').upsert(
+      {
+        id: log.id,
+        user_id: userId,
+        name: log.name,
+        date: log.date,
+        date_label: log.dateLabel,
+        duration: log.duration,
+        exercises: log.exercises,
+      },
+      { onConflict: 'id,user_id' }
+    );
+  } catch {}
+}
+
+export async function syncAllWorkoutLogsToSupabase(userId: string, logs: WorkoutLog[]) {
+  try {
+    await getSupabase().from('workout_logs').delete().eq('user_id', userId);
+    if (logs.length > 0) {
+      await getSupabase().from('workout_logs').upsert(
+        logs.map((log) => ({
+          id: log.id,
+          user_id: userId,
+          name: log.name,
+          date: log.date,
+          date_label: log.dateLabel,
+          duration: log.duration,
+          exercises: log.exercises,
+        })),
+        { onConflict: 'id,user_id' }
+      );
+    }
+  } catch {}
+}
+
+export async function fetchWorkoutHistoryFromSupabase(userId: string): Promise<WorkoutLog[] | null> {
+  try {
+    const { data } = await getSupabase()
+      .from('workout_logs')
+      .select('*')
+      .eq('user_id', userId)
+      .order('date', { ascending: true });
+    if (!data) return null;
+    return data.map((w) => ({
+      id: w.id,
+      name: w.name,
+      date: w.date,
+      dateLabel: w.date_label,
+      duration: w.duration,
+      exercises: w.exercises as WorkoutLog['exercises'],
+    }));
+  } catch {
+    return null;
+  }
+}
+
+// ─── Points ──────────────────────────────────────────────────────────────────
+
+export async function syncPointsToSupabase(
+  userId: string,
+  totalPoints: number,
+  history: WorkoutPointsEntry[]
+) {
+  try {
+    await getSupabase().from('points').upsert({
+      user_id: userId,
+      total_points: totalPoints,
+      updated_at: new Date().toISOString(),
+    });
+
+    await getSupabase().from('points_history').delete().eq('user_id', userId);
+    if (history.length > 0) {
+      await getSupabase().from('points_history').upsert(
+        history.map((e) => ({
+          workout_id: e.workoutId,
+          user_id: userId,
+          date: e.date,
+          workout_name: e.workoutName,
+          volume_points: e.volumePoints,
+          improvement_bonus: e.improvementBonus,
+          streak_bonus: e.streakBonus,
+          consistency_bonus: e.consistencyBonus,
+          total: e.total,
+          improvements: e.improvements,
+          volume: e.volume,
+          streak_days: e.streakDays,
+        })),
+        { onConflict: 'workout_id,user_id' }
+      );
+    }
+  } catch {}
+}
+
+export async function fetchPointsFromSupabase(
+  userId: string
+): Promise<{ totalPoints: number; history: WorkoutPointsEntry[] } | null> {
+  try {
+    const [{ data: pts }, { data: hist }] = await Promise.all([
+      getSupabase().from('points').select('*').eq('user_id', userId).single(),
+      getSupabase()
+        .from('points_history')
+        .select('*')
+        .eq('user_id', userId)
+        .order('date'),
+    ]);
+    if (!pts) return null;
+    return {
+      totalPoints: pts.total_points,
+      history: (hist ?? []).map((e) => ({
+        workoutId: e.workout_id,
+        date: e.date,
+        workoutName: e.workout_name,
+        volumePoints: e.volume_points,
+        improvementBonus: e.improvement_bonus,
+        streakBonus: e.streak_bonus,
+        consistencyBonus: e.consistency_bonus,
+        total: e.total,
+        improvements: e.improvements as string[],
+        volume: e.volume,
+        streakDays: e.streak_days,
+      })),
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ─── Full Sync (pull from Supabase → AsyncStorage) ──────────────────────────
+
+export async function fullSyncFromSupabase(userId: string): Promise<void> {
+  const [profile, routines, schedule, history, points] = await Promise.all([
+    fetchProfileFromSupabase(userId),
+    fetchRoutinesFromSupabase(userId),
+    fetchScheduleFromSupabase(userId),
+    fetchWorkoutHistoryFromSupabase(userId),
+    fetchPointsFromSupabase(userId),
+  ]);
+
+  const writes: Promise<void>[] = [];
+
+  if (profile) {
+    writes.push(AsyncStorage.setItem(PROFILE_KEY, JSON.stringify(profile)));
+  }
+  if (routines) {
+    writes.push(AsyncStorage.setItem(ROUTINES_KEY, JSON.stringify(routines)));
+  }
+  if (schedule) {
+    writes.push(AsyncStorage.setItem(SCHEDULE_KEY, JSON.stringify(schedule)));
+  }
+  if (history) {
+    writes.push(AsyncStorage.setItem(WORKOUT_HISTORY_KEY, JSON.stringify(history)));
+  }
+  if (points) {
+    writes.push(AsyncStorage.setItem(POINTS_KEY, JSON.stringify(points)));
+  }
+
+  await Promise.all(writes);
+}
+
+// ─── Push local data to Supabase (one-time migration) ────────────────────────
+
+export async function pushLocalDataToSupabase(userId: string): Promise<void> {
+  const [profileRaw, routinesRaw, scheduleRaw, historyRaw, pointsRaw] = await Promise.all([
+    AsyncStorage.getItem(PROFILE_KEY),
+    AsyncStorage.getItem(ROUTINES_KEY),
+    AsyncStorage.getItem(SCHEDULE_KEY),
+    AsyncStorage.getItem(WORKOUT_HISTORY_KEY),
+    AsyncStorage.getItem(POINTS_KEY),
+  ]);
+
+  const ops: Promise<unknown>[] = [];
+
+  if (profileRaw) {
+    const profile = JSON.parse(profileRaw) as ProfileData;
+    ops.push(syncProfileToSupabase(userId, profile));
+  }
+  if (routinesRaw) {
+    const routines = JSON.parse(routinesRaw) as Routine[];
+    ops.push(syncRoutinesToSupabase(userId, routines));
+  }
+  if (scheduleRaw) {
+    const schedule = JSON.parse(scheduleRaw) as ScheduleEntry[];
+    ops.push(syncScheduleToSupabase(userId, schedule));
+  }
+  if (historyRaw) {
+    const history = JSON.parse(historyRaw) as WorkoutLog[];
+    ops.push(syncAllWorkoutLogsToSupabase(userId, history));
+  }
+  if (pointsRaw) {
+    const points = JSON.parse(pointsRaw) as { totalPoints: number; history: WorkoutPointsEntry[] };
+    ops.push(syncPointsToSupabase(userId, points.totalPoints, points.history));
+  }
+
+  await Promise.all(ops);
+}

--- a/supabase/migration.sql
+++ b/supabase/migration.sql
@@ -1,0 +1,178 @@
+-- ============================================================================
+-- Workout Tracker — Supabase Migration
+-- Run this in the Supabase SQL Editor to set up all tables, RLS, and triggers.
+-- ============================================================================
+
+-- ─── Profiles ────────────────────────────────────────────────────────────────
+
+create table public.profiles (
+  id          uuid primary key references auth.users(id) on delete cascade,
+  name        text not null default '',
+  goal        text not null default 'Build Muscle',
+  age         text not null default '',
+  weight      text not null default '',
+  height      text not null default '',
+  picture_url text,
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now()
+);
+
+alter table public.profiles enable row level security;
+
+create policy "Users can read own profile"
+  on public.profiles for select using (id = auth.uid());
+create policy "Users can insert own profile"
+  on public.profiles for insert with check (id = auth.uid());
+create policy "Users can update own profile"
+  on public.profiles for update using (id = auth.uid());
+
+-- ─── Routines ────────────────────────────────────────────────────────────────
+
+create table public.routines (
+  id          text not null,
+  user_id     uuid not null references auth.users(id) on delete cascade,
+  name        text not null,
+  tag         text not null default '',
+  exercises   jsonb not null default '[]',
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now(),
+  primary key (id, user_id)
+);
+
+alter table public.routines enable row level security;
+
+create policy "Users can read own routines"
+  on public.routines for select using (user_id = auth.uid());
+create policy "Users can insert own routines"
+  on public.routines for insert with check (user_id = auth.uid());
+create policy "Users can update own routines"
+  on public.routines for update using (user_id = auth.uid());
+create policy "Users can delete own routines"
+  on public.routines for delete using (user_id = auth.uid());
+
+-- ─── Schedules ───────────────────────────────────────────────────────────────
+
+create table public.schedules (
+  user_id     uuid not null references auth.users(id) on delete cascade,
+  day         text not null,
+  routine_id  text,
+  primary key (user_id, day)
+);
+
+alter table public.schedules enable row level security;
+
+create policy "Users can read own schedule"
+  on public.schedules for select using (user_id = auth.uid());
+create policy "Users can insert own schedule"
+  on public.schedules for insert with check (user_id = auth.uid());
+create policy "Users can update own schedule"
+  on public.schedules for update using (user_id = auth.uid());
+create policy "Users can delete own schedule"
+  on public.schedules for delete using (user_id = auth.uid());
+
+-- ─── Workout Logs ────────────────────────────────────────────────────────────
+
+create table public.workout_logs (
+  id          text not null,
+  user_id     uuid not null references auth.users(id) on delete cascade,
+  name        text not null,
+  date        text not null,
+  date_label  text not null default '',
+  duration    text not null default '',
+  exercises   jsonb not null default '[]',
+  created_at  timestamptz not null default now(),
+  primary key (id, user_id)
+);
+
+alter table public.workout_logs enable row level security;
+
+create policy "Users can read own workout logs"
+  on public.workout_logs for select using (user_id = auth.uid());
+create policy "Users can insert own workout logs"
+  on public.workout_logs for insert with check (user_id = auth.uid());
+create policy "Users can update own workout logs"
+  on public.workout_logs for update using (user_id = auth.uid());
+create policy "Users can delete own workout logs"
+  on public.workout_logs for delete using (user_id = auth.uid());
+
+-- ─── Points ──────────────────────────────────────────────────────────────────
+
+create table public.points (
+  user_id      uuid primary key references auth.users(id) on delete cascade,
+  total_points integer not null default 0,
+  updated_at   timestamptz not null default now()
+);
+
+alter table public.points enable row level security;
+
+create policy "Users can read own points"
+  on public.points for select using (user_id = auth.uid());
+create policy "Users can insert own points"
+  on public.points for insert with check (user_id = auth.uid());
+create policy "Users can update own points"
+  on public.points for update using (user_id = auth.uid());
+
+-- ─── Points History ──────────────────────────────────────────────────────────
+
+create table public.points_history (
+  workout_id        text not null,
+  user_id           uuid not null references auth.users(id) on delete cascade,
+  date              text not null,
+  workout_name      text not null,
+  volume_points     integer not null default 0,
+  improvement_bonus integer not null default 0,
+  streak_bonus      integer not null default 0,
+  consistency_bonus integer not null default 0,
+  total             integer not null default 0,
+  improvements      jsonb not null default '[]',
+  volume            integer not null default 0,
+  streak_days       integer not null default 0,
+  primary key (workout_id, user_id)
+);
+
+alter table public.points_history enable row level security;
+
+create policy "Users can read own points history"
+  on public.points_history for select using (user_id = auth.uid());
+create policy "Users can insert own points history"
+  on public.points_history for insert with check (user_id = auth.uid());
+create policy "Users can update own points history"
+  on public.points_history for update using (user_id = auth.uid());
+
+-- ─── Auto-create profile + points on signup ──────────────────────────────────
+
+create or replace function public.handle_new_user()
+returns trigger as $$
+begin
+  insert into public.profiles (id, name)
+  values (new.id, coalesce(new.raw_user_meta_data->>'name', ''));
+  insert into public.points (user_id)
+  values (new.id);
+  return new;
+end;
+$$ language plpgsql security definer;
+
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function public.handle_new_user();
+
+-- ─── Avatars Storage Bucket ──────────────────────────────────────────────────
+-- Create the bucket manually in Dashboard > Storage, then run these policies:
+
+create policy "Users can upload own avatar"
+  on storage.objects for insert
+  with check (
+    bucket_id = 'avatars' and
+    (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+create policy "Users can update own avatar"
+  on storage.objects for update
+  using (
+    bucket_id = 'avatars' and
+    (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+create policy "Public avatar read"
+  on storage.objects for select
+  using (bucket_id = 'avatars');


### PR DESCRIPTION
## Summary
- Add Supabase Postgres tables for all app data (profiles, routines, schedules, workout logs, points) with Row Level Security
- Create write-through sync layer: AsyncStorage as fast local cache, Supabase as source of truth
- All save functions now sync to Supabase when a userId is available
- Full sync from Supabase on login (populates AsyncStorage from cloud)
- Auto-create profile + points rows on user signup via Postgres trigger
- Avatar storage bucket with user-scoped upload policies
- New users start with empty data (removed mock data seeding)

Closes #7

## Setup Required
1. Run `supabase/migration.sql` in your Supabase SQL Editor
2. Create an `avatars` storage bucket in Dashboard > Storage (public, 5MB limit)
3. Supabase env vars must already be set from GH-5

## Architecture
```
Save flow:  Screen → storage.ts (AsyncStorage) → sync.ts (Supabase upsert)
Load flow:  Screen → storage.ts (AsyncStorage, instant)
Login sync: AuthContext → fullSyncFromSupabase → overwrites AsyncStorage
```

## Files Changed
- `supabase/migration.sql` — database schema, RLS, trigger, storage policies
- `lib/sync.ts` — Supabase sync functions for all data types
- `constants/storage.ts` — all save functions accept optional userId for sync
- `contexts/AuthContext.tsx` — fullSync on SIGNED_IN event
- `app/(tabs)/profile.tsx`, `log.tsx`, `schedule.tsx`, `routine/[id].tsx` — pass userId to save calls

## Test plan
- [ ] Run migration SQL in Supabase — all tables created with RLS
- [ ] Sign up new user — profile and points rows auto-created
- [ ] Create a routine — appears in Supabase `routines` table
- [ ] Log a workout — appears in `workout_logs` and `points_history`
- [ ] Edit schedule — appears in `schedules` table
- [ ] Edit profile — appears in `profiles` table
- [ ] Sign out and sign in on different browser — data syncs from Supabase
- [ ] Verify RLS: user cannot see other users' data (test via SQL editor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)