### PR TITLE
Fix stale avatar on user switch (GH-7)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -7,6 +7,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { Colors } from '@/constants/theme';
 import { WORKOUT_DAYS, ROUTINES, Routine } from '@/constants/mockData';
 import { loadRoutines, loadPoints, loadProfile } from '@/constants/storage';
+import { useAuth } from '@/contexts/AuthContext';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -187,6 +188,7 @@ function RoutineCard({ routine }: { routine: Routine }) {
 
 export default function HomeScreen() {
   const router = useRouter();
+  const { user } = useAuth();
   const [routines, setRoutines] = useState<Routine[]>(ROUTINES);
   const [totalPoints, setTotalPoints] = useState(0);
   const [pictureUri, setPictureUri] = useState<string | null>(null);
@@ -196,7 +198,7 @@ export default function HomeScreen() {
       loadRoutines().then(setRoutines);
       loadPoints().then((p) => setTotalPoints(p.totalPoints));
       loadProfile().then((p) => setPictureUri(p.pictureUri));
-    }, [])
+    }, [user?.id])
   );
 
   const hour = new Date().getHours();

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -8,6 +8,7 @@ import { Colors } from '@/constants/theme';
 import { WORKOUT_DAYS, ROUTINES, Routine } from '@/constants/mockData';
 import { loadRoutines, loadPoints, loadProfile } from '@/constants/storage';
 import { useAuth } from '@/contexts/AuthContext';
+import { getSupabase } from '@/lib/supabase';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -193,18 +194,33 @@ export default function HomeScreen() {
   const [totalPoints, setTotalPoints] = useState(0);
   const [pictureUri, setPictureUri] = useState<string | null>(null);
 
+  const fetchAvatar = useCallback(async () => {
+    if (!user?.id) {
+      setPictureUri(null);
+      return;
+    }
+    const filePath = `${user.id}/profile.jpg`;
+    const { data: files } = await getSupabase().storage.from('avatars').list(user.id, { limit: 1, search: 'profile.jpg' });
+    if (files && files.length > 0) {
+      const { data } = getSupabase().storage.from('avatars').getPublicUrl(filePath);
+      setPictureUri(`${data.publicUrl}?t=${Date.now()}`);
+    } else {
+      setPictureUri(null);
+    }
+  }, [user?.id]);
+
   useEffect(() => {
     setPictureUri(null);
     loadRoutines().then(setRoutines);
     loadPoints().then((p) => setTotalPoints(p.totalPoints));
-    loadProfile().then((p) => setPictureUri(p.pictureUri));
-  }, [user?.id]);
+    fetchAvatar();
+  }, [user?.id, fetchAvatar]);
 
   useFocusEffect(
     useCallback(() => {
       loadRoutines().then(setRoutines);
       loadPoints().then((p) => setTotalPoints(p.totalPoints));
-      loadProfile().then((p) => setPictureUri(p.pictureUri));
+      fetchAvatar();
     }, [user?.id])
   );
 

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useFocusEffect, useRouter } from 'expo-router';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Image, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -192,6 +192,13 @@ export default function HomeScreen() {
   const [routines, setRoutines] = useState<Routine[]>(ROUTINES);
   const [totalPoints, setTotalPoints] = useState(0);
   const [pictureUri, setPictureUri] = useState<string | null>(null);
+
+  useEffect(() => {
+    setPictureUri(null);
+    loadRoutines().then(setRoutines);
+    loadPoints().then((p) => setTotalPoints(p.totalPoints));
+    loadProfile().then((p) => setPictureUri(p.pictureUri));
+  }, [user?.id]);
 
   useFocusEffect(
     useCallback(() => {

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -585,13 +585,16 @@ export default function ProfileScreen() {
         const response = await fetch(localUri);
         const blob = await response.blob();
         const filePath = `${user.id}/profile.jpg`;
-        await getSupabase().storage.from('avatars').upload(filePath, blob, {
+        const { error: uploadError } = await getSupabase().storage.from('avatars').upload(filePath, blob, {
           upsert: true,
           contentType: 'image/jpeg',
         });
+        if (uploadError) throw uploadError;
         const { data } = getSupabase().storage.from('avatars').getPublicUrl(filePath);
         pictureUri = `${data.publicUrl}?t=${Date.now()}`;
-      } catch {}
+      } catch (err) {
+        console.error('Avatar upload failed:', err);
+      }
     }
 
     const updated = { ...profile, pictureUri };


### PR DESCRIPTION
## Summary
- Fix home page showing previous user's profile photo after logout/login as different user
- Add error logging for avatar upload failures (previously silently swallowed)

## Test plan
- [ ] Upload profile photo as User A
- [ ] Log out, log in as User B → verify home page shows User B's avatar (or default icon)
- [ ] Open browser console → verify upload errors are logged if upload fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)