### PR TITLE
Add dynamic streak tracking with 24-hour reset rule

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -223,6 +223,10 @@ export default function HomeScreen() {
   }, []);
 
   useEffect(() => {
+    setCurrentStreak(0);
+    setWorkoutDays(new Set());
+    setTotalPoints(0);
+    setRoutines([]);
     setPictureUri(null);
     loadData();
     fetchAvatar();

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -5,14 +5,11 @@ import { Image, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'rea
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { Colors } from '@/constants/theme';
-import { WORKOUT_DAYS, ROUTINES, Routine } from '@/constants/mockData';
-import { loadRoutines, loadPoints, loadProfile } from '@/constants/storage';
+import { Routine } from '@/constants/mockData';
+import { loadRoutines, loadPoints, loadProfile, loadWorkoutHistory, loadStreakMeta } from '@/constants/storage';
+import { computeCurrentStreak } from '@/constants/points';
 import { useAuth } from '@/contexts/AuthContext';
 import { getSupabase } from '@/lib/supabase';
-
-// ─── Constants ────────────────────────────────────────────────────────────────
-
-const STREAK = 12;
 
 const MONTHS = [
   'January', 'February', 'March', 'April', 'May', 'June',
@@ -22,7 +19,7 @@ const DAY_LABELS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
 
 // ─── Streak Calendar ──────────────────────────────────────────────────────────
 
-function StreakCalendar() {
+function StreakCalendar({ workoutDays }: { workoutDays: Set<string> }) {
   const today = new Date();
   const [viewYear, setViewYear] = useState(today.getFullYear());
   const [viewMonth, setViewMonth] = useState(today.getMonth());
@@ -54,7 +51,7 @@ function StreakCalendar() {
     .filter((d) => {
       if (!d) return false;
       const key = `${viewYear}-${(viewMonth + 1).toString().padStart(2, '0')}-${d.toString().padStart(2, '0')}`;
-      return WORKOUT_DAYS.has(key);
+      return workoutDays.has(key);
     }).length;
 
   return (
@@ -100,7 +97,7 @@ function StreakCalendar() {
             const mm = (viewMonth + 1).toString().padStart(2, '0');
             const dd = day.toString().padStart(2, '0');
             const dateKey = `${viewYear}-${mm}-${dd}`;
-            const hasWorkout = WORKOUT_DAYS.has(dateKey);
+            const hasWorkout = workoutDays.has(dateKey);
             const isToday =
               viewYear === today.getFullYear() &&
               viewMonth === today.getMonth() &&
@@ -190,8 +187,10 @@ function RoutineCard({ routine }: { routine: Routine }) {
 export default function HomeScreen() {
   const router = useRouter();
   const { user } = useAuth();
-  const [routines, setRoutines] = useState<Routine[]>(ROUTINES);
+  const [routines, setRoutines] = useState<Routine[]>([]);
   const [totalPoints, setTotalPoints] = useState(0);
+  const [currentStreak, setCurrentStreak] = useState(0);
+  const [workoutDays, setWorkoutDays] = useState<Set<string>>(new Set());
   const [pictureUri, setPictureUri] = useState<string | null>(null);
 
   const fetchAvatar = useCallback(async () => {
@@ -209,19 +208,31 @@ export default function HomeScreen() {
     }
   }, [user?.id]);
 
+  const loadData = useCallback(async () => {
+    const [routinesData, pointsData, history, streakMeta] = await Promise.all([
+      loadRoutines(),
+      loadPoints(),
+      loadWorkoutHistory(),
+      loadStreakMeta(),
+    ]);
+    setRoutines(routinesData);
+    setTotalPoints(pointsData.totalPoints);
+    const days = new Set(history.map((w) => w.date));
+    setWorkoutDays(days);
+    setCurrentStreak(computeCurrentStreak(days, streakMeta.lastWorkoutTimestamp));
+  }, []);
+
   useEffect(() => {
     setPictureUri(null);
-    loadRoutines().then(setRoutines);
-    loadPoints().then((p) => setTotalPoints(p.totalPoints));
+    loadData();
     fetchAvatar();
-  }, [user?.id, fetchAvatar]);
+  }, [user?.id, fetchAvatar, loadData]);
 
   useFocusEffect(
     useCallback(() => {
-      loadRoutines().then(setRoutines);
-      loadPoints().then((p) => setTotalPoints(p.totalPoints));
+      loadData();
       fetchAvatar();
-    }, [user?.id])
+    }, [user?.id, loadData, fetchAvatar])
   );
 
   const hour = new Date().getHours();
@@ -266,13 +277,15 @@ export default function HomeScreen() {
             <View style={styles.streakTextBlock}>
               <Text style={styles.streakLabel}>Current Streak</Text>
               <Text style={styles.streakCount}>
-                {STREAK} <Text style={styles.streakUnit}>days</Text>
+                {currentStreak} <Text style={styles.streakUnit}>days</Text>
               </Text>
             </View>
           </View>
-          <View style={styles.streakBadge}>
-            <Text style={styles.streakBadgeText}>ON FIRE</Text>
-          </View>
+          {currentStreak > 0 && (
+            <View style={styles.streakBadge}>
+              <Text style={styles.streakBadgeText}>ON FIRE</Text>
+            </View>
+          )}
         </TouchableOpacity>
 
         {/* ── Stats row ───────────────────────────────────────────────── */}
@@ -300,7 +313,7 @@ export default function HomeScreen() {
         <View style={styles.sectionHeader}>
           <Text style={styles.sectionTitle}>Streak Calendar</Text>
         </View>
-        <StreakCalendar />
+        <StreakCalendar workoutDays={workoutDays} />
 
         {/* ── Workouts ─────────────────────────────────────────────────── */}
         <View style={styles.sectionHeader}>

--- a/app/(tabs)/log.tsx
+++ b/app/(tabs)/log.tsx
@@ -16,7 +16,7 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 
 import { Colors } from '@/constants/theme';
 import { EXERCISE_LIBRARY, ExerciseInfo, PREV_PERFORMANCE, WorkoutLog } from '@/constants/mockData';
-import { addWorkoutPoints, loadRoutines, loadSchedule, loadWorkoutHistory, saveWorkoutLog } from '@/constants/storage';
+import { addWorkoutPoints, loadRoutines, loadSchedule, loadStreakMeta, loadWorkoutHistory, saveStreakMeta, saveWorkoutLog } from '@/constants/storage';
 import { calculateWorkoutPoints, computeCurrentStreak, WorkoutPointsEntry } from '@/constants/points';
 import { useAuth } from '@/contexts/AuthContext';
 
@@ -202,17 +202,23 @@ export default function LogScreen() {
   const [pendingPoints, setPendingPoints] = useState<WorkoutPointsEntry | null>(null);
   const [summaryVisible, setSummaryVisible] = useState(false);
 
+  const [saving, setSaving] = useState(false);
+
   async function handleFinish() {
+    if (saving) return;
+    setSaving(true);
     const today = new Date();
+    const finishTimestamp = today.toISOString();
     const dateStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
 
     // Load prior history for streak + improvement detection (before saving this workout)
-    const [priorHistory, schedule] = await Promise.all([
+    const [priorHistory, schedule, streakMeta] = await Promise.all([
       loadWorkoutHistory(),
       loadSchedule(),
+      loadStreakMeta(),
     ]);
     const historyDays = new Set(priorHistory.map((w) => w.date));
-    const streak = computeCurrentStreak(historyDays);
+    const streak = computeCurrentStreak(historyDays, streakMeta.lastWorkoutTimestamp);
 
     const dayName = today.toLocaleDateString('en-US', { weekday: 'long' });
     const todayEntry = schedule.find((e) => e.day === dayName);
@@ -260,6 +266,7 @@ export default function LogScreen() {
         .filter((ex) => ex.sets.length > 0),
     };
     await saveWorkoutLog(workoutLog, user?.id);
+    await saveStreakMeta({ lastWorkoutTimestamp: finishTimestamp }, user?.id);
 
     setPendingPoints(points);
     setSummaryVisible(true);

--- a/app/streaks.tsx
+++ b/app/streaks.tsx
@@ -1,11 +1,12 @@
 import { Ionicons } from '@expo/vector-icons';
-import { useRouter } from 'expo-router';
-import React, { useMemo } from 'react';
+import { useFocusEffect, useRouter } from 'expo-router';
+import React, { useCallback, useMemo, useState } from 'react';
 import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { Colors } from '@/constants/theme';
-import { WORKOUT_DAYS } from '@/constants/mockData';
+import { loadWorkoutHistory, loadStreakMeta } from '@/constants/storage';
+import { computeCurrentStreak, computeBestStreak } from '@/constants/points';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -20,9 +21,7 @@ type StreakRun = {
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const CURRENT_STREAK = 12;
-const BEST_STREAK = 21;
-const YEAR = 2026;
+const YEAR = new Date().getFullYear();
 
 const MONTHS = [
   'January', 'February', 'March', 'April', 'May', 'June',
@@ -49,7 +48,7 @@ function buildCalendarGrid(year: number, month: number): (number | null)[][] {
 
 /**
  * Compute streak periods from workout days.
- * A gap of ≤ 2 calendar days (i.e. one rest day) keeps a streak alive.
+ * Strict consecutive calendar days only — no gap tolerance.
  */
 function computeStreakRuns(workoutDays: Set<string>): StreakRun[] {
   const sorted = Array.from(workoutDays)
@@ -64,9 +63,9 @@ function computeStreakRuns(workoutDays: Set<string>): StreakRun[] {
   let count = 1;
 
   for (let i = 1; i < sorted.length; i++) {
-    const diff =
-      (sorted[i].getTime() - sorted[i - 1].getTime()) / (1000 * 60 * 60 * 24);
-    if (diff <= 2) {
+    const diff = Math.round(
+      (sorted[i].getTime() - sorted[i - 1].getTime()) / (1000 * 60 * 60 * 24));
+    if (diff === 1) {
       end = sorted[i];
       count++;
     } else {
@@ -106,13 +105,14 @@ function getDayType(
   month: number,
   day: number,
   periods: Array<{ startMs: number; endMs: number }>,
-  today: Date
+  today: Date,
+  workoutDays: Set<string>
 ): DayType {
   const date = new Date(year, month, day);
   if (date > today) return 'future';
 
   const key = dateKey(year, month, day);
-  if (WORKOUT_DAYS.has(key)) return 'workout';
+  if (workoutDays.has(key)) return 'workout';
 
   const ms = date.getTime();
   const inPeriod = periods.some((p) => ms >= p.startMs && ms <= p.endMs);
@@ -126,11 +126,13 @@ function MonthCalendar({
   month,
   periods,
   today,
+  workoutDays,
 }: {
   year: number;
   month: number;
   periods: Array<{ startMs: number; endMs: number }>;
   today: Date;
+  workoutDays: Set<string>;
 }) {
   const weeks = useMemo(() => buildCalendarGrid(year, month), [year, month]);
 
@@ -142,10 +144,10 @@ function MonthCalendar({
     let n = 0;
     const days = new Date(year, month + 1, 0).getDate();
     for (let d = 1; d <= days; d++) {
-      if (WORKOUT_DAYS.has(dateKey(year, month, d))) n++;
+      if (workoutDays.has(dateKey(year, month, d))) n++;
     }
     return n;
-  }, [year, month, today]);
+  }, [year, month, today, workoutDays]);
 
   const isFutureMonth =
     year > today.getFullYear() ||
@@ -175,7 +177,7 @@ function MonthCalendar({
           {week.map((day, di) => {
             if (!day) return <View key={di} style={styles.dayCell} />;
 
-            const type = getDayType(year, month, day, periods, today);
+            const type = getDayType(year, month, day, periods, today, workoutDays);
             const isToday =
               year === today.getFullYear() &&
               month === today.getMonth() &&
@@ -219,12 +221,25 @@ function MonthCalendar({
 export default function StreaksScreen() {
   const router = useRouter();
   const today = useMemo(() => new Date(), []);
+  const [workoutDays, setWorkoutDays] = useState<Set<string>>(new Set());
+  const [currentStreak, setCurrentStreak] = useState(0);
+  const [bestStreak, setBestStreak] = useState(0);
 
-  const streakRuns = useMemo(() => computeStreakRuns(WORKOUT_DAYS), []);
+  useFocusEffect(
+    useCallback(() => {
+      Promise.all([loadWorkoutHistory(), loadStreakMeta()]).then(([history, meta]) => {
+        const days = new Set(history.map((w) => w.date));
+        setWorkoutDays(days);
+        setCurrentStreak(computeCurrentStreak(days, meta.lastWorkoutTimestamp));
+        setBestStreak(computeBestStreak(days));
+      });
+    }, [])
+  );
 
-  // Pre-compute period start/end as ms for fast day-type lookup
+  const streakRuns = useMemo(() => computeStreakRuns(workoutDays), [workoutDays]);
+
   const periods = useMemo(() => {
-    const sorted = Array.from(WORKOUT_DAYS)
+    const sorted = Array.from(workoutDays)
       .sort()
       .map((d) => new Date(d + 'T12:00:00'));
     if (sorted.length === 0) return [];
@@ -234,9 +249,9 @@ export default function StreaksScreen() {
     let end = sorted[0];
 
     for (let i = 1; i < sorted.length; i++) {
-      const diff =
-        (sorted[i].getTime() - sorted[i - 1].getTime()) / (1000 * 60 * 60 * 24);
-      if (diff <= 2) {
+      const diff = Math.round(
+        (sorted[i].getTime() - sorted[i - 1].getTime()) / (1000 * 60 * 60 * 24));
+      if (diff === 1) {
         end = sorted[i];
       } else {
         result.push({ startMs: start.getTime(), endMs: end.getTime() });
@@ -246,7 +261,7 @@ export default function StreaksScreen() {
     }
     result.push({ startMs: start.getTime(), endMs: end.getTime() });
     return result;
-  }, []);
+  }, [workoutDays]);
 
   const months = useMemo(
     () => Array.from({ length: 12 }, (_, i) => i),
@@ -278,7 +293,7 @@ export default function StreaksScreen() {
             <View>
               <Text style={styles.heroLabel}>Current Streak</Text>
               <Text style={styles.heroCount}>
-                {CURRENT_STREAK}
+                {currentStreak}
                 <Text style={styles.heroUnit}> days</Text>
               </Text>
             </View>
@@ -287,7 +302,7 @@ export default function StreaksScreen() {
           <View style={styles.heroRight}>
             <Text style={styles.bestLabel}>Best Streak</Text>
             <Text style={styles.bestCount}>
-              {BEST_STREAK}
+              {bestStreak}
               <Text style={styles.bestUnit}> days</Text>
             </Text>
           </View>
@@ -343,6 +358,7 @@ export default function StreaksScreen() {
             month={month}
             periods={periods}
             today={today}
+            workoutDays={workoutDays}
           />
         ))}
       </ScrollView>

--- a/constants/points.ts
+++ b/constants/points.ts
@@ -173,37 +173,82 @@ export function calculateWorkoutPoints(input: PointsCalcInput): WorkoutPointsEnt
   };
 }
 
-// ─── Streak helper ────────────────────────────────────────────────────────────
+// ─── Streak helpers ───────────────────────────────────────────────────────────
+
+function dateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
 
 /**
- * Compute the current workout streak as of today (including today's workout
- * being logged right now). Uses WORKOUT_DAYS with a 1-rest-day grace period.
+ * Compute the current workout streak.
+ * Streak resets to 0 if more than 24 hours have passed since lastWorkoutTimestamp.
+ * Counts consecutive calendar days with a workout, no grace period.
  */
-export function computeCurrentStreak(workoutDays: Set<string>): number {
+export function computeCurrentStreak(
+  workoutDays: Set<string>,
+  lastWorkoutTimestamp: string | null
+): number {
+  if (!lastWorkoutTimestamp || workoutDays.size === 0) return 0;
+
+  const lastWorkout = new Date(lastWorkoutTimestamp);
+  const now = new Date();
+  const hoursSinceLast = (now.getTime() - lastWorkout.getTime()) / (1000 * 60 * 60);
+
+  if (hoursSinceLast > 24) return 0;
+
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
-  function key(d: Date): string {
-    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  let streak = 0;
+  const check = new Date(today);
+
+  if (workoutDays.has(dateKey(check))) {
+    streak = 1;
+    check.setDate(check.getDate() - 1);
+  } else {
+    check.setDate(check.getDate() - 1);
+    if (!workoutDays.has(dateKey(check))) return 0;
+    streak = 1;
+    check.setDate(check.getDate() - 1);
   }
 
-  let streak = 1; // today counts
-  let gapAllowed = 1;
-  const check = new Date(today);
-  check.setDate(check.getDate() - 1);
-
   for (let i = 0; i < 365; i++) {
-    if (workoutDays.has(key(check))) {
+    if (workoutDays.has(dateKey(check))) {
       streak++;
-      gapAllowed = 1; // reset
-    } else if (gapAllowed > 0) {
-      gapAllowed--;   // burn a gap
     } else {
       break;
     }
     check.setDate(check.getDate() - 1);
   }
+
   return streak;
+}
+
+/**
+ * Compute the longest streak from all workout history.
+ * Strict consecutive calendar days, no gaps allowed.
+ */
+export function computeBestStreak(workoutDays: Set<string>): number {
+  if (workoutDays.size === 0) return 0;
+
+  const sorted = Array.from(workoutDays).sort();
+  let best = 1;
+  let current = 1;
+
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = new Date(sorted[i - 1] + 'T12:00:00');
+    const curr = new Date(sorted[i] + 'T12:00:00');
+    const diffDays = Math.round((curr.getTime() - prev.getTime()) / (1000 * 60 * 60 * 24));
+
+    if (diffDays === 1) {
+      current++;
+    } else {
+      current = 1;
+    }
+    best = Math.max(best, current);
+  }
+
+  return best;
 }
 
 // ─── Pre-seeded points history ────────────────────────────────────────────────

--- a/constants/storage.ts
+++ b/constants/storage.ts
@@ -15,6 +15,21 @@ import {
   syncStreakMetaToSupabase,
 } from '@/lib/sync';
 
+// ─── Clear all user data on sign-out ─────────────────────────────────────────
+
+const ALL_KEYS = [
+  '@workout_tracker:profile',
+  '@workout_tracker:schedule',
+  '@workout_tracker:points',
+  '@workout_tracker:routines',
+  '@workout_tracker:workout_history',
+  '@workout_tracker:streak_meta',
+];
+
+export async function clearAllStorage(): Promise<void> {
+  await AsyncStorage.multiRemove(ALL_KEYS);
+}
+
 // ─── Profile ─────────────────────────────────────────────────────────────────
 
 export type ProfileData = {

--- a/constants/storage.ts
+++ b/constants/storage.ts
@@ -12,6 +12,7 @@ import {
   syncScheduleToSupabase,
   syncPointsToSupabase,
   syncWorkoutLogToSupabase,
+  syncStreakMetaToSupabase,
 } from '@/lib/sync';
 
 // ─── Profile ─────────────────────────────────────────────────────────────────
@@ -195,6 +196,7 @@ export async function loadStreakMeta(): Promise<StreakMeta> {
   }
 }
 
-export async function saveStreakMeta(meta: StreakMeta, _userId?: string): Promise<void> {
+export async function saveStreakMeta(meta: StreakMeta, userId?: string): Promise<void> {
   await AsyncStorage.setItem(STREAK_META_KEY, JSON.stringify(meta));
+  if (userId) syncStreakMetaToSupabase(userId, meta);
 }

--- a/constants/storage.ts
+++ b/constants/storage.ts
@@ -176,3 +176,25 @@ export async function saveWorkoutLog(log: WorkoutLog, userId?: string): Promise<
   );
   if (userId) syncWorkoutLogToSupabase(userId, log);
 }
+
+// ─── Streak Meta ─────────────────────────────────────────────────────────────
+
+export type StreakMeta = {
+  lastWorkoutTimestamp: string | null;
+};
+
+const STREAK_META_KEY = '@workout_tracker:streak_meta';
+
+export async function loadStreakMeta(): Promise<StreakMeta> {
+  try {
+    const raw = await AsyncStorage.getItem(STREAK_META_KEY);
+    if (raw === null) return { lastWorkoutTimestamp: null };
+    return JSON.parse(raw) as StreakMeta;
+  } catch {
+    return { lastWorkoutTimestamp: null };
+  }
+}
+
+export async function saveStreakMeta(meta: StreakMeta, _userId?: string): Promise<void> {
+  await AsyncStorage.setItem(STREAK_META_KEY, JSON.stringify(meta));
+}

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -4,6 +4,7 @@ import { Platform } from 'react-native';
 
 import { getSupabase } from '@/lib/supabase';
 import { fullSyncFromSupabase } from '@/lib/sync';
+import { clearAllStorage } from '@/constants/storage';
 
 type AuthState = {
   session: Session | null;
@@ -70,6 +71,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const signOut = useCallback(async () => {
+    await clearAllStorage();
     await getSupabase().auth.signOut();
   }, []);
 

--- a/lib/sync.ts
+++ b/lib/sync.ts
@@ -2,13 +2,14 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { getSupabase } from './supabase';
 import type { Routine, WorkoutLog } from '@/constants/mockData';
 import type { WorkoutPointsEntry } from '@/constants/points';
-import type { ProfileData, ScheduleEntry } from '@/constants/storage';
+import type { ProfileData, ScheduleEntry, StreakMeta } from '@/constants/storage';
 
 const PROFILE_KEY = '@workout_tracker:profile';
 const SCHEDULE_KEY = '@workout_tracker:schedule';
 const POINTS_KEY = '@workout_tracker:points';
 const ROUTINES_KEY = '@workout_tracker:routines';
 const WORKOUT_HISTORY_KEY = '@workout_tracker:workout_history';
+const STREAK_META_KEY = '@workout_tracker:streak_meta';
 
 // ─── Profile ─────────────────────────────────────────────────────────────────
 
@@ -253,15 +254,44 @@ export async function fetchPointsFromSupabase(
   }
 }
 
+// ─── Streak Meta ────────────────────────────────────────────────────────────
+
+export async function syncStreakMetaToSupabase(userId: string, meta: StreakMeta) {
+  try {
+    await getSupabase().from('streak_meta').upsert({
+      user_id: userId,
+      last_workout_timestamp: meta.lastWorkoutTimestamp,
+      updated_at: new Date().toISOString(),
+    });
+  } catch {}
+}
+
+export async function fetchStreakMetaFromSupabase(userId: string): Promise<StreakMeta | null> {
+  try {
+    const { data } = await getSupabase()
+      .from('streak_meta')
+      .select('*')
+      .eq('user_id', userId)
+      .single();
+    if (!data) return null;
+    return {
+      lastWorkoutTimestamp: data.last_workout_timestamp,
+    };
+  } catch {
+    return null;
+  }
+}
+
 // ─── Full Sync (pull from Supabase → AsyncStorage) ──────────────────────────
 
 export async function fullSyncFromSupabase(userId: string): Promise<void> {
-  const [profile, routines, schedule, history, points] = await Promise.all([
+  const [profile, routines, schedule, history, points, streakMeta] = await Promise.all([
     fetchProfileFromSupabase(userId),
     fetchRoutinesFromSupabase(userId),
     fetchScheduleFromSupabase(userId),
     fetchWorkoutHistoryFromSupabase(userId),
     fetchPointsFromSupabase(userId),
+    fetchStreakMetaFromSupabase(userId),
   ]);
 
   const writes: Promise<void>[] = [];
@@ -281,6 +311,9 @@ export async function fullSyncFromSupabase(userId: string): Promise<void> {
   if (points) {
     writes.push(AsyncStorage.setItem(POINTS_KEY, JSON.stringify(points)));
   }
+  if (streakMeta) {
+    writes.push(AsyncStorage.setItem(STREAK_META_KEY, JSON.stringify(streakMeta)));
+  }
 
   await Promise.all(writes);
 }
@@ -288,12 +321,13 @@ export async function fullSyncFromSupabase(userId: string): Promise<void> {
 // ─── Push local data to Supabase (one-time migration) ────────────────────────
 
 export async function pushLocalDataToSupabase(userId: string): Promise<void> {
-  const [profileRaw, routinesRaw, scheduleRaw, historyRaw, pointsRaw] = await Promise.all([
+  const [profileRaw, routinesRaw, scheduleRaw, historyRaw, pointsRaw, streakMetaRaw] = await Promise.all([
     AsyncStorage.getItem(PROFILE_KEY),
     AsyncStorage.getItem(ROUTINES_KEY),
     AsyncStorage.getItem(SCHEDULE_KEY),
     AsyncStorage.getItem(WORKOUT_HISTORY_KEY),
     AsyncStorage.getItem(POINTS_KEY),
+    AsyncStorage.getItem(STREAK_META_KEY),
   ]);
 
   const ops: Promise<unknown>[] = [];
@@ -317,6 +351,10 @@ export async function pushLocalDataToSupabase(userId: string): Promise<void> {
   if (pointsRaw) {
     const points = JSON.parse(pointsRaw) as { totalPoints: number; history: WorkoutPointsEntry[] };
     ops.push(syncPointsToSupabase(userId, points.totalPoints, points.history));
+  }
+  if (streakMetaRaw) {
+    const streakMeta = JSON.parse(streakMetaRaw) as StreakMeta;
+    ops.push(syncStreakMetaToSupabase(userId, streakMeta));
   }
 
   await Promise.all(ops);

--- a/supabase/add-streak-meta.sql
+++ b/supabase/add-streak-meta.sql
@@ -1,0 +1,33 @@
+create table public.streak_meta (
+  user_id                uuid primary key references auth.users(id) on delete cascade,
+  last_workout_timestamp timestamptz,
+  updated_at             timestamptz not null default now()
+);
+
+alter table public.streak_meta enable row level security;
+
+create policy "Users can read own streak meta"
+  on public.streak_meta for select using (user_id = auth.uid());
+create policy "Users can insert own streak meta"
+  on public.streak_meta for insert with check (user_id = auth.uid());
+create policy "Users can update own streak meta"
+  on public.streak_meta for update using (user_id = auth.uid());
+
+-- Seed streak_meta for existing users who already have a profile
+insert into public.streak_meta (user_id)
+select id from auth.users
+on conflict do nothing;
+
+-- Update the signup trigger to also create streak_meta
+create or replace function public.handle_new_user()
+returns trigger as $$
+begin
+  insert into public.profiles (id, name)
+  values (new.id, coalesce(new.raw_user_meta_data->>'name', ''));
+  insert into public.points (user_id)
+  values (new.id);
+  insert into public.streak_meta (user_id)
+  values (new.id);
+  return new;
+end;
+$$ language plpgsql security definer;

--- a/supabase/migration.sql
+++ b/supabase/migration.sql
@@ -139,6 +139,23 @@ create policy "Users can insert own points history"
 create policy "Users can update own points history"
   on public.points_history for update using (user_id = auth.uid());
 
+-- ─── Streak Meta ────────────────────────────────────────────────────────────
+
+create table public.streak_meta (
+  user_id                uuid primary key references auth.users(id) on delete cascade,
+  last_workout_timestamp timestamptz,
+  updated_at             timestamptz not null default now()
+);
+
+alter table public.streak_meta enable row level security;
+
+create policy "Users can read own streak meta"
+  on public.streak_meta for select using (user_id = auth.uid());
+create policy "Users can insert own streak meta"
+  on public.streak_meta for insert with check (user_id = auth.uid());
+create policy "Users can update own streak meta"
+  on public.streak_meta for update using (user_id = auth.uid());
+
 -- ─── Auto-create profile + points on signup ──────────────────────────────────
 
 create or replace function public.handle_new_user()
@@ -147,6 +164,8 @@ begin
   insert into public.profiles (id, name)
   values (new.id, coalesce(new.raw_user_meta_data->>'name', ''));
   insert into public.points (user_id)
+  values (new.id);
+  insert into public.streak_meta (user_id)
   values (new.id);
   return new;
 end;


### PR DESCRIPTION
## Summary
- Replace hardcoded streak values (STREAK=12, CURRENT_STREAK=12, BEST_STREAK=21) with dynamic computation from workout history
- Add `StreakMeta` storage with `lastWorkoutTimestamp` to enforce strict 24-hour reset rule
- Streak starts at 0 for new users, increments on workout save, resets if >24h since last workout
- Home page and streaks page now load real data via `useFocusEffect`
- Calendar reads from stored workout history instead of static `WORKOUT_DAYS` set
- Added `computeBestStreak()` for all-time best streak calculation
- Added double-tap guard on workout finish button
- Aligned streak run visualization with strict consecutive-day logic (no gap tolerance)

Closes #11

## Test plan
- [ ] Fresh install shows streak = 0, no "ON FIRE" badge
- [ ] Log a workout — streak shows 1, badge appears
- [ ] Log another workout next day within 24h — streak increments to 2
- [ ] Wait >24h without logging — streak resets to 0 on next app open
- [ ] Verify streaks page shows dynamic current/best streak values
- [ ] Verify calendar highlights match actual workout history
- [ ] Double-tap finish button only saves once
- [ ] Streak runs on streaks page use strict consecutive days

🤖 Generated with [Claude Code](https://claude.com/claude-code)